### PR TITLE
Update pelican Client API Key prefix

### DIFF
--- a/pterodactyl/kitsunelab-cs2-egg.json
+++ b/pterodactyl/kitsunelab-cs2-egg.json
@@ -207,7 +207,7 @@
       "default_value": "",
       "user_viewable": true,
       "user_editable": true,
-      "rules": "nullable|string|regex:/^(ptlc_|plcn_).{43}$/",
+      "rules": "nullable|string|regex:/^(ptlc_|pacc_).{43}$/",
       "field_type": "text"
     },
     {


### PR DESCRIPTION
`plcn_` has been deprecated by Pelican dev team. 
The new prefix is `pacc_` for Client API Key and `papp_` for Application API Key.


Link to the message in their [Discord](https://discord.com/channels/1218730176297439332/1218733575151816774/1413283020965937244)